### PR TITLE
Change Python version. Django 1.11 does not work with 3.7.

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ datetime | consumption
 
 ### Development environment
 
-* Python 3.6 or later
+* Python 3.6.x
 * Django 1.11
 
 To work on the challenge, please fork this repository or download it. After you have finished, you can send us a link to the fork or simply zip the repository and email it to us.


### PR DESCRIPTION
Django 1.11 is not compatible with python 3.7.
We need to change requirement in README.